### PR TITLE
Add scratcher EV scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-"# guagualeEXP" 
+# guagualeEXP
+
+A simple scraper that fetches prize information for Taiwan Lottery scratch games and estimates the expected value of each game after taxes.
+
+## Requirements
+
+- Python 3.11+
+- `requests`
+- `beautifulsoup4`
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the scraper from the command line. You can attempt to fetch live data or load a local JSON file:
+
+```bash
+# fetch live data (may fail if the website is unreachable)
+python scrape.py
+
+# use bundled sample data
+python scrape.py --json data/sample_games.json
+```
+
+The script will request the list of available scratch cards from the official Taiwan Lottery website, fetch the prize structure for each game, and print the expected value for every scratcher sorted from highest to lowest.
+
+> **Note**
+> The official website occasionally blocks automated requests, resulting in `HTTP 503` errors. If fetching live data fails, use the `--json` option with `data/sample_games.json` to see how results are presented.

--- a/data/sample_games.json
+++ b/data/sample_games.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "超級幸運",
+    "price": 200,
+    "prizes": [
+      {"amount": 2000000, "total": 3, "remaining": 1},
+      {"amount": 200000, "total": 50, "remaining": 25},
+      {"amount": 2000, "total": 1000, "remaining": 800}
+    ]
+  },
+  {
+    "name": "好運連連",
+    "price": 500,
+    "prizes": [
+      {"amount": 5000000, "total": 2, "remaining": 1},
+      {"amount": 500000, "total": 20, "remaining": 10},
+      {"amount": 5000, "total": 500, "remaining": 450}
+    ]
+  }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/scrape.py
+++ b/scrape.py
@@ -1,0 +1,120 @@
+import json
+import requests
+from bs4 import BeautifulSoup
+from dataclasses import dataclass, field
+from typing import List, Iterable, Optional
+import argparse
+
+BASE_URL = "https://www.taiwanlottery.com.tw"
+LIST_URL = f"{BASE_URL}/zh-hant/instant/instant_index.aspx"
+
+@dataclass
+class PrizeTier:
+    amount: int
+    total: int
+    remaining: int
+
+@dataclass
+class ScratchGame:
+    name: str
+    price: int
+    url: str
+    prizes: List[PrizeTier] = field(default_factory=list)
+
+    def expected_value(self) -> float:
+        total_remaining = sum(t.remaining for t in self.prizes)
+        if total_remaining == 0:
+            return -self.price
+        # total value after taxes
+        total_value = sum(_net_amount(t.amount) * t.remaining for t in self.prizes)
+        return total_value / total_remaining - self.price
+
+def _net_amount(amount: int) -> float:
+    if amount > 5000:
+        after_tax = amount * 0.8  # 20% winning tax
+        after_tax *= 0.996        # 0.4% stamp tax
+        return after_tax
+    return float(amount)
+
+def fetch_game_list(session: requests.Session) -> List[ScratchGame]:
+    resp = session.get(LIST_URL)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    games = []
+    # The structure may change; this is a best guess using common table layout
+    for a in soup.select("a[href*='instant_']"):
+        name = a.get_text(strip=True)
+        href = a.get("href")
+        if not href:
+            continue
+        if not href.startswith("http"):
+            href = BASE_URL + href
+        # Extract price from sibling element if available
+        price_text = a.find_next("span")
+        price = 0
+        if price_text:
+            digits = ''.join(filter(str.isdigit, price_text.get_text()))
+            price = int(digits) if digits else 0
+        games.append(ScratchGame(name=name, price=price, url=href))
+    return games
+
+
+def load_games_from_json(path: str) -> List[ScratchGame]:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    games: List[ScratchGame] = []
+    for g in data:
+        prizes = [PrizeTier(**p) for p in g.get("prizes", [])]
+        games.append(
+            ScratchGame(name=g.get("name", ""), price=g.get("price", 0), url="", prizes=prizes)
+        )
+    return games
+
+def fetch_game_details(session: requests.Session, game: ScratchGame) -> None:
+    resp = session.get(game.url)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    table = soup.find("table")
+    if not table:
+        return
+    for tr in table.select("tr"):
+        cells = [td.get_text(strip=True) for td in tr.select("td")]
+        if len(cells) < 3:
+            continue
+        try:
+            amount = int(cells[0].replace(',', ''))
+            total = int(cells[1].replace(',', ''))
+            remaining = int(cells[2].replace(',', ''))
+        except ValueError:
+            continue
+        game.prizes.append(PrizeTier(amount, total, remaining))
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Compute scratch card expected value")
+    parser.add_argument("--json", dest="json_path", help="Path to local game data in JSON format")
+    args = parser.parse_args(argv)
+
+    if args.json_path:
+        game_list = load_games_from_json(args.json_path)
+    else:
+        with requests.Session() as s:
+            s.headers.update({"User-Agent": "Mozilla/5.0"})
+            try:
+                game_list = fetch_game_list(s)
+            except Exception as e:
+                print(f"Failed to fetch game list: {e}")
+                return
+            for game in game_list:
+                try:
+                    fetch_game_details(s, game)
+                except Exception as e:
+                    print(f"Failed to fetch {game.name}: {e}")
+
+    game_list.sort(key=lambda g: g.expected_value(), reverse=True)
+    for g in game_list:
+        ev = g.expected_value()
+        print(f"{g.name}\tPrice: {g.price}\tEV: {ev:.2f}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python scraper `scrape.py` to fetch Taiwan Lottery scratcher details and compute expected value after tax
- document setup and basic usage in README
- add offline JSON data option for environments where live scraping fails

## Testing
- `python -m py_compile scrape.py`


------
https://chatgpt.com/codex/tasks/task_e_684ee1e77720832fae2dc79e4df785bc